### PR TITLE
Allow custom humanize keys

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -56,9 +56,11 @@ class TimeDifference
     end]
   end
 
-  def humanize
+  def humanize(only_parts = TIME_COMPONENTS)
     diff_parts = []
-    in_general.each do |part,quantity|
+    whitelisted_general = in_general.select { |part, _| only_parts.include?(part) }
+
+    whitelisted_general.each do |part, quantity|
       next if quantity <= 0
       part = part.to_s.humanize
 
@@ -78,7 +80,7 @@ class TimeDifference
   end
 
   private
-  
+
   def initialize(start_time, end_time)
     start_time = time_in_seconds(start_time)
     end_time = time_in_seconds(end_time)

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -48,10 +48,21 @@ describe TimeDifference do
   describe "#humanize" do
     with_each_class do |clazz|
       it "returns a string representing the time difference from in_general" do
-        start_time = clazz.new(2009, 11)
+        start_time = clazz.new(2009, 11, 5)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).humanize).to eql("1 Year, 2 Months and 18 Hours")
+        expect(TimeDifference.between(start_time, end_time).humanize).to eql("1 Year, 1 Month, 3 Weeks, 5 Days and 18 Hours")
+      end
+    end
+
+    context "informing what parts I want" do
+      with_each_class do |clazz|
+        it "returns a string representing the time difference containing only the desired keys" do
+          start_time = clazz.new(2009, 11, 5)
+          end_time = clazz.new(2011, 1)
+
+          expect(TimeDifference.between(start_time, end_time).humanize([:years, :months])).to eql("1 Year and 1 Month")
+        end
       end
     end
   end

--- a/time_difference.gemspec
+++ b/time_difference.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "time_difference"
   gem.require_paths = ["lib"]
-  gem.version       = "0.5.0"
+  gem.version       = "0.6.0"
   gem.license = 'MIT'
 
   gem.add_runtime_dependency('activesupport')


### PR DESCRIPTION
Added a parameter to `humanize` function so we can specify what parts we want.

For the `humanize` call:

=> "1 Year, 1 Month, 3 Weeks, 5 Days and 18 Hours"

If we call `humanize([:years, :months])` the output contains only the informed parts:

=> "1 Year and 1 Month"